### PR TITLE
支持302重定向，Header支持go template渲染

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,4 +49,4 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: .
-        tags: ${{ step.meta.outputs.tags }}
+        tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,10 +43,11 @@ jobs:
     - name: Login to DockerHub
       uses: docker/login-action@v1
       with:
-        Username: ${{ secrets.DOCKERHUB_ORG_USERNAME }}
+        username: ${{ secrets.DOCKERHUB_ORG_USERNAME }}
         password: ${{ secrets.DOCKERHUB_ORG_ACCESS_TOKEN }}
     - name: Build and push
       uses: docker/build-push-action@v2
       with:
         context: .
+        push: true
         tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,13 +28,6 @@ jobs:
       run: go test -race -coverprofile=coverage.txt -covermode=atomic -v ./...
     - name: Test Coverage Report
       run: bash <(curl -s https://codecov.io/bash)
-#    - uses: docker/build-push-action@v1
-#      with:
-#        username: ${{ secrets.DOCKERHUB_ORG_USERNAME }}
-#        password: ${{ secrets.DOCKERHUB_ORG_ACCESS_TOKEN }}
-#        repository: wosai/deepmock
-#        tag_with_ref: true
-#        tag_with_sha: true
     - name: Docker meta
       id: meta
       uses: docker/metadata-actions@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
     - name: Login to DockerHub
+      uses: docker/login-action@v1
       with:
         username: ${{ secrets.DOCKERHUB_ORG_USERNAME }}
         password: ${{ secrets.DOCKERHUB_ORG_ACCESS_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
     - name: Login to DockerHub
       uses: docker/login-action@v1
       with:
-        username: ${{ secrets.DOCKERHUB_ORG_USERNAME }}
+        Username: ${{ secrets.DOCKERHUB_ORG_USERNAME }}
         password: ${{ secrets.DOCKERHUB_ORG_ACCESS_TOKEN }}
     - name: Build and push
       uses: docker/build-push-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       run: bash <(curl -s https://codecov.io/bash)
     - name: Docker meta
       id: meta
-      uses: docker/metadata-actions@v3
+      uses: docker/metadata-action@v3
       with:
         images: |
           wosai/deepmock

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,10 +28,31 @@ jobs:
       run: go test -race -coverprofile=coverage.txt -covermode=atomic -v ./...
     - name: Test Coverage Report
       run: bash <(curl -s https://codecov.io/bash)
-    - uses: docker/build-push-action@v1
+#    - uses: docker/build-push-action@v1
+#      with:
+#        username: ${{ secrets.DOCKERHUB_ORG_USERNAME }}
+#        password: ${{ secrets.DOCKERHUB_ORG_ACCESS_TOKEN }}
+#        repository: wosai/deepmock
+#        tag_with_ref: true
+#        tag_with_sha: true
+    - name: Docker meta
+      id: meta
+      uses: docker/metadata-actions@v3
+      with:
+        images: |
+          wosai/deepmock
+        tags: |
+          type=ref, event=branch
+          type=ref, event=pr
+          type=sha
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+    - name: Login to DockerHub
       with:
         username: ${{ secrets.DOCKERHUB_ORG_USERNAME }}
         password: ${{ secrets.DOCKERHUB_ORG_ACCESS_TOKEN }}
-        repository: wosai/deepmock
-        tag_with_ref: true
-        tag_with_sha: true
+    - name: Build and push
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        tags: ${{ step.meta.outputs.tags }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+
+## 0.6.0 - 2021-11-19
+
+### Added
+
+- 新增对于Response.Header使用Go Template的支持
+
+### Changed 
+
+- DTO新增支持字段is_header_template
+
+### Fixed
+
+- 修复创建规则时，StatusCode设置不生效的问题

--- a/application/rule.go
+++ b/application/rule.go
@@ -89,12 +89,12 @@ func convertRegulationDTO(reg *types.RegulationDTO) *domain.Regulation {
 	}
 	if reg.Template != nil {
 		r.Template = &domain.Template{
-			IsTemplate:         reg.Template.IsTemplate,
-			IsLocationTemplate: reg.Template.IsLocationTemplate,
-			Header:             reg.Template.Header,
-			Body:               reg.Template.Body,
-			B64EncodedBody:     reg.Template.B64EncodeBody,
-			StatusCode:         reg.Template.StatusCode, // 默认不传，设置为200
+			IsTemplate:       reg.Template.IsTemplate,
+			IsHeaderTemplate: reg.Template.IsHeaderTemplate,
+			Header:           reg.Template.Header,
+			Body:             reg.Template.Body,
+			B64EncodedBody:   reg.Template.B64EncodeBody,
+			StatusCode:       reg.Template.StatusCode, // 默认不传，设置为200
 		}
 		if reg.Template.StatusCode == 0 {
 			r.Template.StatusCode = http.StatusOK

--- a/application/rule.go
+++ b/application/rule.go
@@ -89,10 +89,12 @@ func convertRegulationDTO(reg *types.RegulationDTO) *domain.Regulation {
 	}
 	if reg.Template != nil {
 		r.Template = &domain.Template{
-			IsTemplate:     reg.Template.IsTemplate,
-			Header:         reg.Template.Header,
-			Body:           reg.Template.Body,
-			B64EncodedBody: reg.Template.B64EncodeBody,
+			IsTemplate:         reg.Template.IsTemplate,
+			IsLocationTemplate: reg.Template.IsLocationTemplate,
+			Header:             reg.Template.Header,
+			Body:               reg.Template.Body,
+			B64EncodedBody:     reg.Template.B64EncodeBody,
+			StatusCode:         reg.Template.StatusCode, // 默认不传，设置为200
 		}
 		if reg.Template.StatusCode == 0 {
 			r.Template.StatusCode = http.StatusOK

--- a/domain/executor_test.go
+++ b/domain/executor_test.go
@@ -275,75 +275,61 @@ func TestRuleExecutor_Minimal(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestHeaderTemplate(t *testing.T) {
-	var rc RenderContext
-	rc.Variable = map[string]interface{}{
+func TestHandleHeaderTemplate(t *testing.T) {
+	// 测试遍历header并修改的函数handleHeaderTemplate
+	ctx := &fasthttp.RequestCtx{
+		Request: fasthttp.Request{
+			Header: fasthttp.RequestHeader{},
+		},
+	}
+	ctx.Request.SetBody([]byte("{\"hello\":\"{{.Variable.name}}\", \"country\":\"{{.Query.country}}\",\"body\":\"{{.Form.nickname}}\"}"))
+	ctx.Request.Header.SetRequestURIBytes([]byte("http://localhost:16600/redirect/baidu?redirect_uri=https%3A%2F%2Fwww.baidu.com&appid=appid&state=true"))
+
+	// 模拟response header
+	te := &TemplateExecutor{}
+	te.header = &fasthttp.ResponseHeader{}
+	te.header.Set("fake", "1")
+	te.header.Set("rand-string", "{{rand_string 20}}")
+	te.header.Set("user-agent", "Wechat")
+	te.header.Set("uuid", "{{uuid}}")
+	te.header.Set("Not-Exist-Func", "{{not_exist_func}}")
+	te.header.Set("location", "{{.Query.redirect_uri}}?state={{.Query.state}}&app_id={{.Variable.app_id}}&auth_code={{.Variable.code}}")
+
+	v := map[string]interface{}{
 		"app_id": "app_id",
 		"code":   "123456",
 	}
-	rc.Weight = map[string]string{}
-	rc.Header = map[string]string{}
-	rc.Query = map[string]string{
-		"appid":        "appid",
-		"redirect_url": "https%3A%2F%2Fwww.baidu.com",
-		"state":        "true",
-	}
-	rc.Form = map[string]string{}
-	rc.Json = map[string]interface{}{}
-	var buf bytes.Buffer
-	tmpl, err := template.New("test").Parse("{{.Query.redirect_url}}?state={{.Query.state}}&app_id={{.Variable.app_id}}&code={{.Variable.code}}")
-	assert.Nil(t, err)
-	err = tmpl.Execute(&buf, rc)
+
+	err := te.handleHeaderTemplate(ctx, v, nil)
 	assert.Nil(t, err)
 
-	decodeUrl, _ := url.QueryUnescape(buf.String())
-	assert.Equal(t, decodeUrl, "https://www.baidu.com?state=true&app_id=app_id&code=123456")
+	fmt.Println("\n>>>>>>After render, the te.header is:")
+	fmt.Println(string(te.header.Header()))
+	decodeUrl, _ := url.QueryUnescape(string(te.header.Peek("Location")))
+	assert.Equal(t, decodeUrl, "https://www.baidu.com?state=true&app_id=app_id&auth_code=123456")
+	assert.Equal(t, string(te.header.Peek("not-exist-func")), "{{not_exist_func}}")
 }
 
-func TestModifyHeader(t *testing.T) {
-	// 测试遍历header并修改
-	header := &fasthttp.ResponseHeader{}
-	header.Set("fake", "1")
-	header.Set("rand-string", "{{rand_string 20}}")
-	header.Set("user-agent", "Wechat")
-	header.Set("uuid", "{{uuid}}")
-	header.Set("Not-Exist-Func", "{{not_exist_func}}")
-	header.Set("location", "{{.Query.redirect_uri}}?state={{.Query.state}}&app_id={{.Variable.app_id}}&auth_code={{.Variable.code}}")
+func TestParseParams(t *testing.T) {
+	ctx := &fasthttp.RequestCtx{
+		Request: fasthttp.Request{
+			Header: fasthttp.RequestHeader{},
+		},
+	}
 
-	var rc RenderContext
-	rc.Variable = map[string]interface{}{
+	ctx.Request.SetBody([]byte("{\"hello\":\"{{.Variable.name}}\", \"country\":\"{{.Query.country}}\",\"body\":\"{{.Form.nickname}}\"}"))
+	ctx.Request.Header.SetRequestURIBytes([]byte("http://localhost:16600/redirect/baidu?redirect_uri=https%3A%2F%2Fwww.baidu.com&appid=appid&state=true"))
+
+	v := map[string]interface{}{
 		"app_id": "app_id",
 		"code":   "123456",
 	}
-	rc.Query = map[string]string{
-		"appid":        "appid",
-		"redirect_uri": "https%3A%2F%2Fwww.baidu.com",
-		"state":        "true",
-	}
+	rc := &RenderContext{}
+	rc.parseParams(ctx, v, nil)
 
-	reg := regexp.MustCompile("{{.+}}")
-	assert.NotNil(t, reg)
-
-	header.VisitAll(func(key, value []byte) {
-		strKey := string(key)
-		strValue := string(value)
-		if reg.MatchString(strValue) {
-			var buf bytes.Buffer
-			tmpl, err := template.New("headerTemplate").Funcs(defaultTemplateFuncs).Parse(strValue)
-			if err != nil {
-				return
-			}
-			err = tmpl.Execute(&buf, rc)
-			if err != nil {
-				return
-			}
-			// set key with rendered value
-			header.Set(strKey, buf.String())
-		}
-	})
-
-	fmt.Println("After render, the header is:")
-	fmt.Println(string(header.Header()))
-	decodeUrl, _ := url.QueryUnescape(string(header.Peek("Location")))
-	assert.Equal(t, decodeUrl, "https://www.baidu.com?state=true&app_id=app_id&auth_code=123456")
+	assert.Equal(t, rc.Query["redirect_uri"], "https://www.baidu.com")
+	assert.Equal(t, rc.Query["appid"], "appid")
+	assert.Equal(t, rc.Query["state"], "true")
+	assert.Equal(t, rc.Variable["app_id"], "app_id")
+	assert.Equal(t, rc.Variable["code"], "123456")
 }

--- a/domain/rule.go
+++ b/domain/rule.go
@@ -40,11 +40,12 @@ type (
 
 	// Template 模板值对象
 	Template struct {
-		IsTemplate     bool              `json:"is_template,omitempty"`
-		Header         map[string]string `json:"header,omitempty"`
-		StatusCode     int               `json:"status_code,omitempty"`
-		Body           string            `json:"body,omitempty"`
-		B64EncodedBody string            `json:"b64encoded_body,omitempty"`
+		IsTemplate         bool              `json:"is_template,omitempty"`
+		IsLocationTemplate bool              `json:"is_location_template,omitempty"`
+		Header             map[string]string `json:"header,omitempty"`
+		StatusCode         int               `json:"status_code,omitempty"`
+		Body               string            `json:"body,omitempty"`
+		B64EncodedBody     string            `json:"b64encoded_body,omitempty"`
 	}
 
 	// WeightFactor 权重因子值对象
@@ -378,9 +379,10 @@ func (bfp BodyFilterParams) To() (*BodyFilterExecutor, error) {
 // To 转换成TemplateExecutor
 func (tmp *Template) To() (*TemplateExecutor, error) {
 	te := &TemplateExecutor{
-		IsGolangTemplate: tmp.IsTemplate,
-		IsBinData:        false,
-		template:         nil,
+		IsGolangTemplate:   tmp.IsTemplate,
+		IsLocationTemplate: tmp.IsLocationTemplate,
+		IsBinData:          false,
+		template:           nil,
 	}
 
 	if tmp.B64EncodedBody != "" {

--- a/domain/rule.go
+++ b/domain/rule.go
@@ -40,12 +40,12 @@ type (
 
 	// Template 模板值对象
 	Template struct {
-		IsTemplate         bool              `json:"is_template,omitempty"`
-		IsLocationTemplate bool              `json:"is_location_template,omitempty"`
-		Header             map[string]string `json:"header,omitempty"`
-		StatusCode         int               `json:"status_code,omitempty"`
-		Body               string            `json:"body,omitempty"`
-		B64EncodedBody     string            `json:"b64encoded_body,omitempty"`
+		IsTemplate       bool              `json:"is_template,omitempty"`
+		IsHeaderTemplate bool              `json:"is_header_template,omitempty"`
+		Header           map[string]string `json:"header,omitempty"`
+		StatusCode       int               `json:"status_code,omitempty"`
+		Body             string            `json:"body,omitempty"`
+		B64EncodedBody   string            `json:"b64encoded_body,omitempty"`
 	}
 
 	// WeightFactor 权重因子值对象
@@ -379,10 +379,10 @@ func (bfp BodyFilterParams) To() (*BodyFilterExecutor, error) {
 // To 转换成TemplateExecutor
 func (tmp *Template) To() (*TemplateExecutor, error) {
 	te := &TemplateExecutor{
-		IsGolangTemplate:   tmp.IsTemplate,
-		IsLocationTemplate: tmp.IsLocationTemplate,
-		IsBinData:          false,
-		template:           nil,
+		IsGolangTemplate: tmp.IsTemplate,
+		IsHeaderTemplate: tmp.IsHeaderTemplate,
+		IsBinData:        false,
+		template:         nil,
 	}
 
 	if tmp.B64EncodedBody != "" {

--- a/misc/util_test.go
+++ b/misc/util_test.go
@@ -7,4 +7,5 @@ import (
 
 func TestGenID(t *testing.T) {
 	fmt.Println(GenID([]byte("/rpc/token"), []byte("POST")))
+	fmt.Println(GenID([]byte("^/$"), []byte("GET")))
 }

--- a/types/dto.go
+++ b/types/dto.go
@@ -40,11 +40,11 @@ type (
 
 	// TemplateDTO 模板的HTTP报文结构
 	TemplateDTO struct {
-		IsTemplate         bool              `json:"is_template,omitempty"`
-		IsLocationTemplate bool              `json:"is_location_template,omitempty"`
-		Header             map[string]string `json:"header,omitempty"`
-		StatusCode         int               `json:"status_code,omitempty"`
-		Body               string            `json:"body,omitempty"`
-		B64EncodeBody      string            `json:"base64encoded_body,omitempty"`
+		IsTemplate       bool              `json:"is_template,omitempty"`
+		IsHeaderTemplate bool              `json:"is_header_template,omitempty"`
+		Header           map[string]string `json:"header,omitempty"`
+		StatusCode       int               `json:"status_code,omitempty"`
+		Body             string            `json:"body,omitempty"`
+		B64EncodeBody    string            `json:"base64encoded_body,omitempty"`
 	}
 )

--- a/types/dto.go
+++ b/types/dto.go
@@ -40,10 +40,11 @@ type (
 
 	// TemplateDTO 模板的HTTP报文结构
 	TemplateDTO struct {
-		IsTemplate    bool              `json:"is_template,omitempty"`
-		Header        map[string]string `json:"header,omitempty"`
-		StatusCode    int               `json:"status_code,omitempty"`
-		Body          string            `json:"body,omitempty"`
-		B64EncodeBody string            `json:"base64encoded_body,omitempty"`
+		IsTemplate         bool              `json:"is_template,omitempty"`
+		IsLocationTemplate bool              `json:"is_location_template,omitempty"`
+		Header             map[string]string `json:"header,omitempty"`
+		StatusCode         int               `json:"status_code,omitempty"`
+		Body               string            `json:"body,omitempty"`
+		B64EncodeBody      string            `json:"base64encoded_body,omitempty"`
 	}
 )


### PR DESCRIPTION
支持mock重定向的服务，且Response.Header中的key-value支持go template渲染，可从query string、自定义variable或者Request.Header中获取特定的信息；

示例：
创建规则需多传一个变量`is_header_template: true`：
```
curl --location --request POST 'http://localhost:16600/api/v1/rule' \
--header 'Content-Type: application/json' \
--data-raw '{
	"path": "/redirect/baidu",
	"method": "get",
    "variable": {
		"app_id": "app_id",
		"code":   "123456"
	},
    "responses": [
        {
            "is_default": true,
            "response": {
                "is_template":false,
                "is_header_template":true,
                "header": {
                    "Content-Type": "text/html",
                    "User-Agent": "Wechat",
                    "x-env-flag": "test-111",
                    "rand-string": "{{rand_string 10}}",
                    "timestamp-sec": "{{timestamp \"sec\"}}",
                    "uuid": "{{uuid}}",
                    "not-exist-func":"{{not_exist_func}}",
                    "location": "{{.Query.redirect_uri}}?state={{.Query.state}}&app_id={{.Variable.app_id}}&code={{.Variable.code}}"
                },
                "status_code": 302
            }
        }
    ]
}
'
```
使用实例：通过curl -I命令查看重定向过程：
`curl -I --location --request GET 'http://localhost:16600/redirect/baidu?redirect_uri=https%3A%2F%2Fwww.baidu.com&appid=appid&state=true'`
输出：
![image](https://user-images.githubusercontent.com/27724893/142560718-1bad85f9-77d8-4a6f-ad93-664a2f189c7a.png)


