### PR TITLE
支持302重定向，Header支持go template渲染

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,35 +3,51 @@ name: ci
 on:
   pull_request:
     branches:
-    - master
+      - master
   push:
     branchs:
-    - release/*
-    - hotfix/*
-    - master
+      - release/*
+      - hotfix/*
+      - master
     tags:
-    - v*
+      - v*
 
 jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
     steps:
-    - name: Set up Go 1.x
-      uses: actions/setup-go@v2
-      with:
-        go-version: ^1.14
-      id: go
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
-    - name: Test
-      run: go test -race -coverprofile=coverage.txt -covermode=atomic -v ./...
-    - name: Test Coverage Report
-      run: bash <(curl -s https://codecov.io/bash)
-    - uses: docker/build-push-action@v1
-      with:
-        username: ${{ secrets.DOCKERHUB_ORG_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_ORG_ACCESS_TOKEN }}
-        repository: wosai/deepmock
-        tag_with_ref: true
-        tag_with_sha: true
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v2
+        with:
+          go-version: ^1.14
+        id: go
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+      - name: Test
+        run: go test -race -coverprofile=coverage.txt -covermode=atomic -v ./...
+      - name: Test Coverage Report
+        run: bash <(curl -s https://codecov.io/bash)
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: |
+            wosai/deepmock
+          tags: |
+            type=ref, event=branch
+            type=ref, event=pr
+            type=sha
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_ORG_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_ORG_ACCESS_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@
 # vscode
 .vscode
 .env
+/deepmock.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Changed 
 
 - DTO新增支持字段render_header和header_template
+- Github Action升级docker/build-push-action@v2
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+
+## 0.6.0 - 2021-11-19
+
+### Added
+
+- 新增对于Response.Header使用Go Template的支持
+
+### Changed 
+
+- DTO新增支持字段is_header_template
+
+### Fixed
+
+- 修复创建规则时，StatusCode设置不生效的问题

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 
-## 0.6.0 - 2021-11-19
+## 0.6.0 - 2021-12-03
 
 ### Added
 
@@ -9,7 +9,7 @@
 
 ### Changed 
 
-- DTO新增支持字段is_header_template
+- DTO新增支持字段render_header和header_template
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ curl -X POST http://127.0.0.1:16600/api/v1/rule \
     * 可以使用内置函数
     * 可以自定义函数
 - 规则中的`Variable`、`Weight`以及请求中的`Header`、`Query`、`Form`、`Json`同样参与Response模板的渲染
-- Response.body中使用template渲染时，需设置`is_template: true`，Response.header中使用template渲染时，需设置`is_header_template: true`
+- Response.body中使用template渲染时，需设置`is_template: true`
+- Response.header可采用Patch形式，使用template渲染部分Header字段，需设置`render_template: true`以及template字符串`header_template`
 
 ### 接口列表：
 
@@ -398,54 +399,53 @@ curl http://127.0.0.1:16600/api/v1/rule/bba079deaa2b97037694a89386616d88
 |`timestamp` | `precision` | `{{timestamp ms}}` | 按指定的精度返回unix时间戳：mcs,ms,sec|
 |`plus`| `v`, `i` | `{{plus v i}}` | 将v的值增加i，实现简单的计算，支持string\int\float类型|
 |`rand_string`| `n` | `{{rand_string n}}`| 生成长度为n的随机字符串 |
+|`html_unescaped`|无|`{{.Variable.str `&#x7c;`html_unescaped}}`| 防止template渲染时，将部分字符进行html编码，如"&" --> "\&amp;" |
  
-#### Response.Header使用Template渲染
+#### Response.Header使用Template渲染示例
 ```json
 {
-    "path": "/redirect/baidu",
-    "method": "get",
-    "variable": {
-        "app_id": "app_id",
-        "code":   "123456"
-	},
-    "responses": [
-        {
-            "is_default": true,
-            "response": {
-                "is_template":false,
-                "is_header_template":true,
-                "header": {
-                    "Content-Type": "text/html",
-                    "User-Agent": "Wechat",
-                    "x-env-flag": "test-111",
-                    "rand-string": "{{rand_string 10}}",
-                    "timestamp-sec": "{{timestamp \"sec\"}}",
-                    "uuid": "{{uuid}}",
-                    "not-exist-func":"{{not_exist_func}}", // not exist func will not be rendered
-                    "location": "{{.Query.redirect_uri}}?state={{.Query.state}}&app_id={{.Variable.app_id}}&code={{.Variable.code}}"
-                },
-                "status_code": 302
-            }
-        }
-    ]
+  "path": "/redirect/baidu",
+  "method": "get",
+  "variable": {
+    "app_id": "app_id",
+    "code": "123456"
+  },
+  "responses": [
+    {
+      "is_default": true,
+      "response": {
+        "is_template": false,
+        "render_header": true,
+        "header": {
+          "Content-Type": "text/html",
+          "User-Agent": "Wechat",
+          "x-env-flag": "test-111",
+          "rand-string": "I'm a {{rand_string}}",
+          "timestamp-sec": "2021-01-01",
+          "uuid": "I'm a {{uuid}}",
+          "location": "https://www.bing.com"
+        },
+        "header_template": "{\"location\": \"{{.Query.redirect_uri | html_unescaped}}&state={{.Query.state}}&app_id={{.Variable.app_id}}&auth_code={{.Variable.code}}\",\"rand-string\":\"{{rand_string 20}}\",\"uuid\":\"{{uuid}}\", \"timestamp-sec\":\"{{timestamp \"sec\"}}\"}",
+        "status_code": 302
+      }
+    }
+  ]
 }
-
 ```
-```typescript
-curl -I --location --request GET 'http://localhost:16600/redirect/baidu?redirect_uri=https%3A%2F%2Fwww.baidu.com&appid=appid&state=true'
+```
+curl -I --location --request GET 'http://localhost:16600/redirect/baidu?redirect_uri=https%3A%2F%2Fwww.baidu.com%3Fref%3Dhello&appid=appid&state=true'
 
 HTTP/1.1 302 Found
 Server: DeepMock Service
-Date: Fri, 19 Nov 2021 02:27:18 GMT
+Date: Fri, 03 Dec 2021 03:49:55 GMT
 Content-Type: text/html
 Content-Length: 0
-Not-Exist-Func: {{not_exist_func}}
-Rand-String: L1cGikKZx3
-Timestamp-Sec: 1637288839
-Uuid: cb871cc9-84d0-4b00-a036-a575ba06889e
+Location: https://www.baidu.com?ref=hello&state=true&app_id=app_id&auth_code=123456
+Rand-String: YHYEglVGzYB8FIIKbify
+Timestamp-Sec: 1638503396
+Uuid: 1cb6c914-04d7-40fe-908f-73d202bb63ea
 X-Env-Flag: test-111
 User-Agent: Wechat
-Location: https://www.baidu.com?state=true&app_id=app_id&code=123456
 ```
 
 ### Benchmark

--- a/application/rule.go
+++ b/application/rule.go
@@ -89,12 +89,12 @@ func convertRegulationDTO(reg *types.RegulationDTO) *domain.Regulation {
 	}
 	if reg.Template != nil {
 		r.Template = &domain.Template{
-			IsTemplate:         reg.Template.IsTemplate,
-			IsLocationTemplate: reg.Template.IsLocationTemplate,
-			Header:             reg.Template.Header,
-			Body:               reg.Template.Body,
-			B64EncodedBody:     reg.Template.B64EncodeBody,
-			StatusCode:         reg.Template.StatusCode, // 默认不传，设置为200
+			IsTemplate:       reg.Template.IsTemplate,
+			IsHeaderTemplate: reg.Template.IsHeaderTemplate,
+			Header:           reg.Template.Header,
+			Body:             reg.Template.Body,
+			B64EncodedBody:   reg.Template.B64EncodeBody,
+			StatusCode:       reg.Template.StatusCode, // 默认不传，设置为200
 		}
 		if reg.Template.StatusCode == 0 {
 			r.Template.StatusCode = http.StatusOK

--- a/application/rule.go
+++ b/application/rule.go
@@ -89,12 +89,13 @@ func convertRegulationDTO(reg *types.RegulationDTO) *domain.Regulation {
 	}
 	if reg.Template != nil {
 		r.Template = &domain.Template{
-			IsTemplate:       reg.Template.IsTemplate,
-			IsHeaderTemplate: reg.Template.IsHeaderTemplate,
-			Header:           reg.Template.Header,
-			Body:             reg.Template.Body,
-			B64EncodedBody:   reg.Template.B64EncodeBody,
-			StatusCode:       reg.Template.StatusCode, // 默认不传，设置为200
+			IsTemplate:     reg.Template.IsTemplate,
+			RenderHeader:   reg.Template.RenderHeader,
+			Header:         reg.Template.Header,
+			HeaderTemplate: reg.Template.HeaderTemplate,
+			Body:           reg.Template.Body,
+			B64EncodedBody: reg.Template.B64EncodeBody,
+			StatusCode:     reg.Template.StatusCode, // 默认不传，设置为200
 		}
 		if reg.Template.StatusCode == 0 {
 			r.Template.StatusCode = http.StatusOK
@@ -128,11 +129,13 @@ func convertRegulationVO(reg *domain.Regulation) *types.RegulationDTO {
 	r := &types.RegulationDTO{
 		IsDefault: reg.IsDefault,
 		Template: &types.TemplateDTO{
-			IsTemplate:    reg.Template.IsTemplate,
-			Header:        reg.Template.Header,
-			StatusCode:    reg.Template.StatusCode,
-			Body:          reg.Template.Body,
-			B64EncodeBody: reg.Template.B64EncodedBody,
+			IsTemplate:     reg.Template.IsTemplate,
+			RenderHeader:   reg.Template.RenderHeader,
+			Header:         reg.Template.Header,
+			HeaderTemplate: reg.Template.HeaderTemplate,
+			StatusCode:     reg.Template.StatusCode,
+			Body:           reg.Template.Body,
+			B64EncodeBody:  reg.Template.B64EncodedBody,
 		},
 	}
 

--- a/application/rule.go
+++ b/application/rule.go
@@ -89,10 +89,12 @@ func convertRegulationDTO(reg *types.RegulationDTO) *domain.Regulation {
 	}
 	if reg.Template != nil {
 		r.Template = &domain.Template{
-			IsTemplate:     reg.Template.IsTemplate,
-			Header:         reg.Template.Header,
-			Body:           reg.Template.Body,
-			B64EncodedBody: reg.Template.B64EncodeBody,
+			IsTemplate:         reg.Template.IsTemplate,
+			IsLocationTemplate: reg.Template.IsLocationTemplate,
+			Header:             reg.Template.Header,
+			Body:               reg.Template.Body,
+			B64EncodedBody:     reg.Template.B64EncodeBody,
+			StatusCode:         reg.Template.StatusCode, // 默认不传，设置为200
 		}
 		if reg.Template.StatusCode == 0 {
 			r.Template.StatusCode = http.StatusOK

--- a/domain/executor_test.go
+++ b/domain/executor_test.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"github.com/stretchr/testify/assert"
 	"github.com/valyala/fasthttp"
+	"github.com/wosai/deepmock/misc"
 	"html/template"
-	"net/url"
 	"regexp"
 	"testing"
 )
@@ -283,31 +283,70 @@ func TestHandleHeaderTemplate(t *testing.T) {
 		},
 	}
 	ctx.Request.SetBody([]byte("{\"hello\":\"{{.Variable.name}}\", \"country\":\"{{.Query.country}}\",\"body\":\"{{.Form.nickname}}\"}"))
-	ctx.Request.Header.SetRequestURIBytes([]byte("http://localhost:16600/redirect/baidu?redirect_uri=https%3A%2F%2Fwww.baidu.com&appid=appid&state=true"))
+	ctx.Request.Header.SetRequestURIBytes([]byte("http://localhost:16600/redirect/baidu?redirect_uri=https%3A%2F%2Fwww.baidu.com%3Fx-env-flag%3Dhavok21%26_ref%3Dt&appid=appid&state=true"))
 
 	// 模拟response header
 	te := &TemplateExecutor{}
 	te.header = &fasthttp.ResponseHeader{}
 	te.header.Set("fake", "1")
-	te.header.Set("rand-string", "{{rand_string 20}}")
+	te.header.Set("rand-string", "I'm a {{rand_string}}")
 	te.header.Set("user-agent", "Wechat")
-	te.header.Set("uuid", "{{uuid}}")
+	te.header.Set("uuid", "I'm a {{uuid}}")
 	te.header.Set("Not-Exist-Func", "{{not_exist_func}}")
-	te.header.Set("location", "{{.Query.redirect_uri}}?state={{.Query.state}}&app_id={{.Variable.app_id}}&auth_code={{.Variable.code}}")
-
+	te.header.Set("location", "https://www.bing.com")
+	str := "{\"location\": \"{{.Query.redirect_uri | html_unescaped}}&state={{.Query.state}}&app_id={{.Variable.app_id}}&auth_code={{.Variable.code}}\"," +
+		"\"rand-string\":\"{{rand_string 20}}\"," +
+		"\"uuid\":\"{{uuid}}\"}"
+	te.headerTemplate, _ = template.New(misc.GenRandomString(9)).Funcs(defaultTemplateFuncs).Parse(str)
 	v := map[string]interface{}{
 		"app_id": "app_id",
 		"code":   "123456",
 	}
 
-	err := te.handleHeaderTemplate(ctx, v, nil)
+	te.header.CopyTo(&ctx.Response.Header)
+	fmt.Println("\n<<<<<<Before render, the response.header is:")
+	fmt.Println(string(ctx.Response.Header.Header()))
+
+	var rc = &RenderContext{}
+	err := te.handleHeaderTemplate(rc, ctx, v, nil)
 	assert.Nil(t, err)
 
-	fmt.Println("\n>>>>>>After render, the te.header is:")
-	fmt.Println(string(te.header.Header()))
-	decodeUrl, _ := url.QueryUnescape(string(te.header.Peek("Location")))
-	assert.Equal(t, decodeUrl, "https://www.baidu.com?state=true&app_id=app_id&auth_code=123456")
-	assert.Equal(t, string(te.header.Peek("not-exist-func")), "{{not_exist_func}}")
+	fmt.Println(">>>>>>After render, the response.header is:")
+	fmt.Println(string(ctx.Response.Header.Header()))
+	assert.Equal(t, string(ctx.Response.Header.Peek("Location")), "https://www.baidu.com?x-env-flag=havok21&_ref=t&state=true&app_id=app_id&auth_code=123456")
+	assert.Equal(t, string(ctx.Response.Header.Peek("not-exist-func")), "{{not_exist_func}}")
+}
+
+func TestHeaderRendering(t *testing.T) {
+	tests := []struct {
+		input, wanted string
+	}{
+		{"http://localhost:16600/redirect?redirect_uri=https%3A%2F%2Fwww.baidu.com%3Fx-env-flag%3Dhavok21%26_ref%3Dt&appid=appid&state=true",
+			"https://www.baidu.com?x-env-flag=havok21&_ref=t&state=true&app_id=app_id&auth_code=123456"}, // normal case
+		{"http://localhost:16600/redirect?redirect_uri=https%3A%2F%2Fwww.baidu.com%26_ref%3D123&appid=appid&state=true",
+			"https://www.baidu.com&_ref=123&state=true&app_id=app_id&auth_code=123456"}, // change _ref
+		{"http://localhost:16600/redirect?redirect_uri=https%3A%2F%2Fwww.baidu.com%26_ref%3D123&appid=appid&state=false",
+			"https://www.baidu.com&_ref=123&state=false&app_id=app_id&auth_code=123456"}, // change state
+		{"http://localhost:16600/redirect?redirect_uri=https%3A%2F%2Fwww.baidu.com%26_ref%3D123&appid=appid",
+			"https://www.baidu.com&_ref=123&state=&app_id=app_id&auth_code=123456"}, // don't have query_string
+		{"http://localhost:16600/redirect",
+			"https://www.bing.com"},
+	}
+
+	for _, test := range tests {
+		RenderHeaderLocation(test.input, test.wanted, t)
+	}
+}
+
+func TestParseString(t *testing.T) {
+	str := "{\"Location\": \"https://www.baidu.com?x-env-flag=havok21&amp;_ref=t&state=true&app_id=app_id&auth_code=123456\"}"
+	headerMap := make(map[string]string)
+
+	err := json.Unmarshal([]byte(str), &headerMap)
+	if err != nil {
+		return
+	}
+	assert.Equal(t, headerMap["Location"], "https://www.baidu.com?x-env-flag=havok21&amp;_ref=t&state=true&app_id=app_id&auth_code=123456")
 }
 
 func TestParseParams(t *testing.T) {
@@ -332,4 +371,38 @@ func TestParseParams(t *testing.T) {
 	assert.Equal(t, rc.Query["state"], "true")
 	assert.Equal(t, rc.Variable["app_id"], "app_id")
 	assert.Equal(t, rc.Variable["code"], "123456")
+}
+
+func RenderHeaderLocation(input, want string, t *testing.T) {
+	// 根据请求的URI，计算渲染后的Response.Header.Location，然后进行比对
+	ctx := &fasthttp.RequestCtx{
+		Request: fasthttp.Request{
+			Header: fasthttp.RequestHeader{},
+		},
+	}
+	ctx.Request.SetBody([]byte("{\"hello\":\"{{.Variable.name}}\", \"country\":\"{{.Query.country}}\",\"body\":\"{{.Form.nickname}}\"}"))
+	ctx.Request.Header.SetRequestURIBytes([]byte(input))
+
+	// 模拟response header
+	te := &TemplateExecutor{}
+	te.header = &fasthttp.ResponseHeader{}
+	te.header.Set("fake", "1")
+	te.header.Set("user-agent", "Wechat")
+	te.header.Set("location", "https://www.bing.com")
+	str := "{\"location\": \"{{.Query.redirect_uri | html_unescaped}}&state={{.Query.state}}&app_id={{.Variable.app_id}}&auth_code={{.Variable.code}}\"," +
+		"\"rand-string\":\"{{rand_string 20}}\"," +
+		"\"uuid\":\"{{uuid}}\"}"
+	te.headerTemplate, _ = template.New(misc.GenRandomString(9)).Funcs(defaultTemplateFuncs).Parse(str)
+	v := map[string]interface{}{
+		"app_id": "app_id",
+		"code":   "123456",
+	}
+
+	te.header.CopyTo(&ctx.Response.Header)
+
+	var rc = &RenderContext{}
+	err := te.handleHeaderTemplate(rc, ctx, v, nil)
+	fmt.Println(err)
+
+	assert.Equal(t, string(ctx.Response.Header.Peek("location")), want)
 }

--- a/domain/rule.go
+++ b/domain/rule.go
@@ -40,12 +40,13 @@ type (
 
 	// Template 模板值对象
 	Template struct {
-		IsTemplate       bool              `json:"is_template,omitempty"`
-		IsHeaderTemplate bool              `json:"is_header_template,omitempty"`
-		Header           map[string]string `json:"header,omitempty"`
-		StatusCode       int               `json:"status_code,omitempty"`
-		Body             string            `json:"body,omitempty"`
-		B64EncodedBody   string            `json:"b64encoded_body,omitempty"`
+		IsTemplate     bool              `json:"is_template,omitempty"`
+		RenderHeader   bool              `json:"render_header,omitempty"`
+		Header         map[string]string `json:"header,omitempty"`
+		HeaderTemplate string            `json:"header_template,omitempty"`
+		StatusCode     int               `json:"status_code,omitempty"`
+		Body           string            `json:"body,omitempty"`
+		B64EncodedBody string            `json:"b64encoded_body,omitempty"`
 	}
 
 	// WeightFactor 权重因子值对象
@@ -380,9 +381,10 @@ func (bfp BodyFilterParams) To() (*BodyFilterExecutor, error) {
 func (tmp *Template) To() (*TemplateExecutor, error) {
 	te := &TemplateExecutor{
 		IsGolangTemplate: tmp.IsTemplate,
-		IsHeaderTemplate: tmp.IsHeaderTemplate,
+		RenderHeader:     tmp.RenderHeader,
 		IsBinData:        false,
 		template:         nil,
+		headerTemplate:   nil,
 	}
 
 	if tmp.B64EncodedBody != "" {
@@ -409,6 +411,13 @@ func (tmp *Template) To() (*TemplateExecutor, error) {
 			return nil, err
 		}
 		te.template = tmpl
+	}
+	if te.RenderHeader {
+		tmpl, err := template.New(misc.GenRandomString(9)).Funcs(defaultTemplateFuncs).Parse(tmp.HeaderTemplate)
+		if err != nil {
+			return nil, err
+		}
+		te.headerTemplate = tmpl
 	}
 	return te, nil
 }

--- a/domain/rule.go
+++ b/domain/rule.go
@@ -40,11 +40,12 @@ type (
 
 	// Template 模板值对象
 	Template struct {
-		IsTemplate     bool              `json:"is_template,omitempty"`
-		Header         map[string]string `json:"header,omitempty"`
-		StatusCode     int               `json:"status_code,omitempty"`
-		Body           string            `json:"body,omitempty"`
-		B64EncodedBody string            `json:"b64encoded_body,omitempty"`
+		IsTemplate         bool              `json:"is_template,omitempty"`
+		IsLocationTemplate bool              `json:"is_location_template,omitempty"`
+		Header             map[string]string `json:"header,omitempty"`
+		StatusCode         int               `json:"status_code,omitempty"`
+		Body               string            `json:"body,omitempty"`
+		B64EncodedBody     string            `json:"b64encoded_body,omitempty"`
 	}
 
 	// WeightFactor 权重因子值对象
@@ -378,9 +379,10 @@ func (bfp BodyFilterParams) To() (*BodyFilterExecutor, error) {
 // To 转换成TemplateExecutor
 func (tmp *Template) To() (*TemplateExecutor, error) {
 	te := &TemplateExecutor{
-		IsGolangTemplate: tmp.IsTemplate,
-		IsBinData:        false,
-		template:         nil,
+		IsGolangTemplate:   tmp.IsTemplate,
+		IsLocationTemplate: tmp.IsLocationTemplate,
+		IsBinData:          false,
+		template:           nil,
 	}
 
 	if tmp.B64EncodedBody != "" {

--- a/domain/rule.go
+++ b/domain/rule.go
@@ -40,12 +40,12 @@ type (
 
 	// Template 模板值对象
 	Template struct {
-		IsTemplate         bool              `json:"is_template,omitempty"`
-		IsLocationTemplate bool              `json:"is_location_template,omitempty"`
-		Header             map[string]string `json:"header,omitempty"`
-		StatusCode         int               `json:"status_code,omitempty"`
-		Body               string            `json:"body,omitempty"`
-		B64EncodedBody     string            `json:"b64encoded_body,omitempty"`
+		IsTemplate       bool              `json:"is_template,omitempty"`
+		IsHeaderTemplate bool              `json:"is_header_template,omitempty"`
+		Header           map[string]string `json:"header,omitempty"`
+		StatusCode       int               `json:"status_code,omitempty"`
+		Body             string            `json:"body,omitempty"`
+		B64EncodedBody   string            `json:"b64encoded_body,omitempty"`
 	}
 
 	// WeightFactor 权重因子值对象
@@ -379,10 +379,10 @@ func (bfp BodyFilterParams) To() (*BodyFilterExecutor, error) {
 // To 转换成TemplateExecutor
 func (tmp *Template) To() (*TemplateExecutor, error) {
 	te := &TemplateExecutor{
-		IsGolangTemplate:   tmp.IsTemplate,
-		IsLocationTemplate: tmp.IsLocationTemplate,
-		IsBinData:          false,
-		template:           nil,
+		IsGolangTemplate: tmp.IsTemplate,
+		IsHeaderTemplate: tmp.IsHeaderTemplate,
+		IsBinData:        false,
+		template:         nil,
 	}
 
 	if tmp.B64EncodedBody != "" {

--- a/misc/util_test.go
+++ b/misc/util_test.go
@@ -7,4 +7,5 @@ import (
 
 func TestGenID(t *testing.T) {
 	fmt.Println(GenID([]byte("/rpc/token"), []byte("POST")))
+	fmt.Println(GenID([]byte("^/$"), []byte("GET")))
 }

--- a/types/dto.go
+++ b/types/dto.go
@@ -40,11 +40,12 @@ type (
 
 	// TemplateDTO 模板的HTTP报文结构
 	TemplateDTO struct {
-		IsTemplate       bool              `json:"is_template,omitempty"`
-		IsHeaderTemplate bool              `json:"is_header_template,omitempty"`
-		Header           map[string]string `json:"header,omitempty"`
-		StatusCode       int               `json:"status_code,omitempty"`
-		Body             string            `json:"body,omitempty"`
-		B64EncodeBody    string            `json:"base64encoded_body,omitempty"`
+		IsTemplate     bool              `json:"is_template,omitempty"`
+		RenderHeader   bool              `json:"render_header,omitempty"`
+		Header         map[string]string `json:"header,omitempty"`
+		HeaderTemplate string            `json:"header_template,omitempty"`
+		StatusCode     int               `json:"status_code,omitempty"`
+		Body           string            `json:"body,omitempty"`
+		B64EncodeBody  string            `json:"base64encoded_body,omitempty"`
 	}
 )

--- a/types/dto.go
+++ b/types/dto.go
@@ -40,11 +40,11 @@ type (
 
 	// TemplateDTO 模板的HTTP报文结构
 	TemplateDTO struct {
-		IsTemplate         bool              `json:"is_template,omitempty"`
-		IsLocationTemplate bool              `json:"is_location_template,omitempty"`
-		Header             map[string]string `json:"header,omitempty"`
-		StatusCode         int               `json:"status_code,omitempty"`
-		Body               string            `json:"body,omitempty"`
-		B64EncodeBody      string            `json:"base64encoded_body,omitempty"`
+		IsTemplate       bool              `json:"is_template,omitempty"`
+		IsHeaderTemplate bool              `json:"is_header_template,omitempty"`
+		Header           map[string]string `json:"header,omitempty"`
+		StatusCode       int               `json:"status_code,omitempty"`
+		Body             string            `json:"body,omitempty"`
+		B64EncodeBody    string            `json:"base64encoded_body,omitempty"`
 	}
 )

--- a/types/dto.go
+++ b/types/dto.go
@@ -40,10 +40,11 @@ type (
 
 	// TemplateDTO 模板的HTTP报文结构
 	TemplateDTO struct {
-		IsTemplate    bool              `json:"is_template,omitempty"`
-		Header        map[string]string `json:"header,omitempty"`
-		StatusCode    int               `json:"status_code,omitempty"`
-		Body          string            `json:"body,omitempty"`
-		B64EncodeBody string            `json:"base64encoded_body,omitempty"`
+		IsTemplate         bool              `json:"is_template,omitempty"`
+		IsLocationTemplate bool              `json:"is_location_template,omitempty"`
+		Header             map[string]string `json:"header,omitempty"`
+		StatusCode         int               `json:"status_code,omitempty"`
+		Body               string            `json:"body,omitempty"`
+		B64EncodeBody      string            `json:"base64encoded_body,omitempty"`
 	}
 )


### PR DESCRIPTION
支持mock重定向的服务，且Response.Header中的key-value支持go template渲染，可从query string、自定义variable或者Request.Header中获取特定的信息；

示例：
创建规则需多传变量`render_header: true`和`header_template`：
```
curl --location --request POST 'http://localhost:16600/api/v1/rule' \
--header 'Content-Type: application/json' \
--data-raw '{
  "path": "/redirect/baidu",
  "method": "get",
  "variable": {
    "app_id": "app_id",
    "code": "123456"
  },
  "responses": [
    {
      "is_default": true,
      "response": {
        "is_template": false,
        "render_header": true,
        "header": {
          "Content-Type": "text/html",
          "User-Agent": "Wechat",
          "x-env-flag": "test-111",
          "rand-string": "I'\''m a {{rand_string}}",
          "timestamp-sec": "2021-01-01",
          "uuid": "I'\''m a {{uuid}}",
          "location": "https://www.bing.com"
        },
        "header_template": "{\"location\": \"{{.Query.redirect_uri | html_unescaped}}&state={{.Query.state}}&app_id={{.Variable.app_id}}&auth_code={{.Variable.code}}\",\"rand-string\":\"{{rand_string 20}}\",\"uuid\":\"{{uuid}}\", \"timestamp-sec\":\"{{timestamp \"sec\"}}\"}",
        "status_code": 302
      }
    }
  ]
}'
```

使用示例：通过curl -I命令查看重定向过程（被渲染的header将和预先设定的静态header进行merge）：
`curl -I --location --request GET 'http://localhost:16600/redirect/baidu?redirect_uri=https%3A%2F%2Fwww.baidu.com%3Fref%3Delloh&appid=appid&state=true'`
输出：
![image](https://user-images.githubusercontent.com/27724893/144558172-eeab211b-88f5-40e8-ba40-d6c153318968.png)



