### PR TITLE
修复Github CI未成功响应push: branch事件的问题

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
   push:
-    branchs:
+    branches:
       - release/*
       - hotfix/*
       - master

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.6.2 - 2021-12-03
+
+### Fixed
+
+- 修复Github CI未成功响应push: branch事件的问题
+
 ## 0.6.1 - 2021-12-03
 
 ### Fixed


### PR DESCRIPTION
branches拼错导致的